### PR TITLE
Configure settings related to whitespace

### DIFF
--- a/init.el
+++ b/init.el
@@ -6,3 +6,4 @@
 (load-file "lisp/dired-mode-changes.el")
 (load-file "lisp/prog-mode-changes.el")
 (load-file "lisp/vc-mode-changes.el")
+(load-file "lisp/whitespace-changes.el")

--- a/lisp/whitespace-changes.el
+++ b/lisp/whitespace-changes.el
@@ -1,0 +1,7 @@
+;; Modifications related to whitespace management
+
+;; Disable tab indentation
+(setq-default indent-tabs-mode nil)
+
+;; Remove trailing whitespace before save.
+(add-hook 'before-save-hook 'delete-trailing-whitespace)


### PR DESCRIPTION
Two simple changes:

1. Disable tab indentation for compatibility between editors
2. Delete trailing whitespace before save. 