### PR TITLE
Configuration for misc. Emacs settings

### DIFF
--- a/init.el
+++ b/init.el
@@ -2,6 +2,7 @@
 ;; this init.el file should only be used to load changes organized in sibling
 ;; elisp-files.
 
+(load-file "lisp/basic-configuration-changes.el")
 (load-file "lisp/nxml-mode-changes.el")
 (load-file "lisp/dired-mode-changes.el")
 (load-file "lisp/prog-mode-changes.el")

--- a/lisp/basic-configuration-changes.el
+++ b/lisp/basic-configuration-changes.el
@@ -1,0 +1,10 @@
+;; Assorted configurations that deal with core Emacs functionality
+
+(fset 'yes-or-no-p 'y-or-n-p)
+
+(setq
+ auto-save-default nil
+ backup-inhibited t
+ confirm-nonexistent-file-or-buffer nil
+ create-lockfiles nil
+ mouse-wheel-progressive-speed nil)


### PR DESCRIPTION
1. Disables default backup creation and lockfiles (will require Emacs 24.3)
2. Disables confirm when entering into new file/buffer
3. Switches yes/no -> y/n
4. Disable mouse scrolling acceleration