### PR TITLE
Added electric pair mode, also added braces as a custom pair

### DIFF
--- a/lisp/basic-configuration-changes.el
+++ b/lisp/basic-configuration-changes.el
@@ -14,3 +14,5 @@
 			      ;;Make electric-pair-mode work on more brackets
                               (?\{ . ?\});;Define braces
                               ) )
+;;Show matching pairs of brackets
+(show-paren-mode t)

--- a/lisp/basic-configuration-changes.el
+++ b/lisp/basic-configuration-changes.el
@@ -9,10 +9,5 @@
  create-lockfiles nil
  mouse-wheel-progressive-speed nil)
 
-(electric-pair-mode 1)
-(defvar electric-pair-pairs '(
-			      ;;Make electric-pair-mode work on more brackets
-                              (?\{ . ?\});;Define braces
-                              ) )
 ;;Show matching pairs of brackets
 (show-paren-mode t)

--- a/lisp/basic-configuration-changes.el
+++ b/lisp/basic-configuration-changes.el
@@ -8,3 +8,9 @@
  confirm-nonexistent-file-or-buffer nil
  create-lockfiles nil
  mouse-wheel-progressive-speed nil)
+
+(electric-pair-mode 1)
+(defvar electric-pair-pairs '(
+			      ;;Make electric-pair-mode work on more brackets
+                              (?\{ . ?\});;Define braces
+                              ) )


### PR DESCRIPTION
Turn on electric pair mode by default, also added braces as a custom pair which automatically hooks to major modes like C, C++= and so on. 

We can also define other characters *, / for org-mode if you want, but I see org-mode isn't on the list(yet?). 