### PR TITLE
Start the mode-line with buffer information.

### DIFF
--- a/init.el
+++ b/init.el
@@ -3,6 +3,7 @@
 ;; elisp-files.
 
 (load-file "lisp/nxml-mode-changes.el")
+(load-file "lisp/mode-line-changes.el")
 (load-file "lisp/dired-mode-changes.el")
 (load-file "lisp/prog-mode-changes.el")
 (load-file "lisp/vc-mode-changes.el")

--- a/lisp/mode-line-changes.el
+++ b/lisp/mode-line-changes.el
@@ -1,0 +1,3 @@
+(setq-default mode-line-format
+              (cons "  "
+                    (member 'mode-line-frame-identification mode-line-format)))

--- a/lisp/mode-line-changes.el
+++ b/lisp/mode-line-changes.el
@@ -1,3 +1,3 @@
 (setq-default mode-line-format
-              (cons "  "
-                    (member 'mode-line-frame-identification mode-line-format)))
+              (append '(" " mode-line-modified)
+                      (member 'mode-line-frame-identification mode-line-format)))


### PR DESCRIPTION
This removes the mode-line constructs that are before the buffer-name construct.

Also, it is safe to load `lisp/mode-line-changes` several times.