### PR TITLE
Disable tool bar

### DIFF
--- a/init.el
+++ b/init.el
@@ -2,6 +2,7 @@
 ;; this init.el file should only be used to load changes organized in sibling
 ;; elisp-files.
 
+(load-file "lisp/appearance-changes.el")
 (load-file "lisp/nxml-mode-changes.el")
 (load-file "lisp/dired-mode-changes.el")
 (load-file "lisp/prog-mode-changes.el")

--- a/lisp/appearance-changes.el
+++ b/lisp/appearance-changes.el
@@ -1,0 +1,1 @@
+(tool-bar-mode -1)


### PR DESCRIPTION
I believe the 1980s toolbar icons are off-putting to most people who try emacs for the first time nowadays. Until we have a better replacement it would make sense for this project to just get rid of them. People just aren't going to use emacs if it looks like this.

![image](https://cloud.githubusercontent.com/assets/52205/25769266/7085ac88-31c9-11e7-9d36-194eb58eaae4.png)
