### PR TITLE
Add linum-mode to prog-mode

### DIFF
--- a/lisp/prog-mode-changes.el
+++ b/lisp/prog-mode-changes.el
@@ -8,4 +8,6 @@
 
 (require 'prog-mode)
 (add-hook 'prog-mode-hook (lambda ()
-                            (company-mode 1)))
+			    (company-mode 1)))
+(add-hook 'prog-mode-hook (lambda ()
+			    (linum-mode 1)))


### PR DESCRIPTION
linum-mode adds line numbers down the left-hand margin.  This would
appear in all programming modes.

This seems to be a common and expected feature in code editors.