### PR TITLE
Increase the GC-cons threshold

### DIFF
--- a/lisp/basic-configuration-changes.el
+++ b/lisp/basic-configuration-changes.el
@@ -11,3 +11,8 @@
  mouse-wheel-progressive-speed nil)
 
 (define-key global-map [remap list-buffers] 'ibuffer)
+
+;; Allow 20MB of memory (instead of 0.76MB default) before calling
+;; garbage collection. This means GC runs less often, which speeds
+;; up some operations
+(setq gc-cons-threshold 20000000)


### PR DESCRIPTION
This was nicked straight from [sensible-defaults](https://github.com/hrs/sensible-defaults.el) btw. But most of us here use it I think and hey its 2017 memory is cheap.