### PR TITLE
Enabled delete-selection-mode

### DIFF
--- a/lisp/basic-configuration-changes.el
+++ b/lisp/basic-configuration-changes.el
@@ -11,3 +11,6 @@
  mouse-wheel-progressive-speed nil)
 
 (define-key global-map [remap list-buffers] 'ibuffer)
+
+;; Typed text will replace a highlighted region
+(delete-selection-mode 1)

--- a/lisp/macos.el
+++ b/lisp/macos.el
@@ -16,9 +16,8 @@
 ;; ...is this broken?
 (setq mac-emulate-three-button-mouse t)
 
-;; shift-select and delete-selection are standard is OS X inputs
-(setq shift-select-mode t) 
-(delete-selection-mode t)
+;; shift-select is standard in OS X inputs
+(setq shift-select-mode t)
 
 ;;;; Normalize key bindings with Mac OS X system ones
 


### PR DESCRIPTION
Typed text will replace a highlighted region. This is default behavior for just about every text editor other than Emacs. Plus, it just makes sense.