### PR TITLE
Set backspace to delete 1 character instead of 1 column

### DIFF
--- a/lisp/basic-configuration-changes.el
+++ b/lisp/basic-configuration-changes.el
@@ -14,3 +14,7 @@
 
 ;; Typed text will replace a highlighted region
 (delete-selection-mode 1)
+
+;; By default, backspace on Emacs turns a tab character into a set of spaces
+;; & deletes one. This sets backspace to delete 1 character instead of 1 column.
+(global-set-key (kbd "DEL") 'backward-delete-char)


### PR DESCRIPTION
By default, backspace on Emacs turns a tab character into space characters of equal length, then deletes one of those spaces. This is contrary to every other editor in existence, which just deletes the tab character, and makes it difficult for the user to quickly delete multiple tabs.