### PR TITLE
Enable show-paren-mode in prog-mode.  Use the mixed style.

### DIFF
--- a/lisp/prog-mode-changes.el
+++ b/lisp/prog-mode-changes.el
@@ -15,5 +15,3 @@
 (add-hook 'prog-mode-hook (lambda ()
                             (show-paren-mode 1)
                             (show-paren-style 'mixed)))
-(add-hook 'prog-mode-hook (lambda ()
-                            (electric-pair-mode 1)))

--- a/lisp/prog-mode-changes.el
+++ b/lisp/prog-mode-changes.el
@@ -11,3 +11,7 @@
                             (company-mode 1)))
 (add-hook 'prog-mode-hook (lambda ()
                             (linum-mode 1)))
+
+(add-hook 'prog-mode-hook (lambda ()
+                            (show-paren-mode 1)
+                            (show-paren-style 'mixed)))

--- a/lisp/prog-mode-changes.el
+++ b/lisp/prog-mode-changes.el
@@ -15,3 +15,5 @@
 (add-hook 'prog-mode-hook (lambda ()
                             (show-paren-mode 1)
                             (show-paren-style 'mixed)))
+(add-hook 'prog-mode-hook (lambda ()
+                            (electric-pair-mode 1)))


### PR DESCRIPTION
Was suggested by #18 but there hasn't been a pull request yet.  I enabled it with the "mixed" style, which highlights only parens when they are both visible, else highlights the region between the parens when both are not visible.

This is helpful when envisioning the scope of what's being enclosed in a set of parens.