### PR TITLE
Simple structure for a "GUI"-mode with associated hook.

### DIFF
--- a/init.el
+++ b/init.el
@@ -3,6 +3,7 @@
 ;; elisp-files.
 
 (load-file "lisp/basic-configuration-changes.el")
+(load-file "lisp/gui-configuration-changes.el")
 (load-file "lisp/nxml-mode-changes.el")
 (load-file "lisp/dired-mode-changes.el")
 (load-file "lisp/isearch-changes.el")

--- a/lisp/gui-configuration-changes.el
+++ b/lisp/gui-configuration-changes.el
@@ -1,0 +1,17 @@
+
+(defvar gui-mode-hook nil
+  "Hook for when Emacs is executed with a GUI/Windowing system.")
+
+;; define default GUI hooks here.
+
+;; (add-hook 'gui-mode-hook (lambda ()
+;;                            (show-paren-mode 1)))
+
+;; actual hook-activation
+
+(defun gui-mode-initialize ()
+  (when (display-graphic-p)
+    (run-hooks 'gui-mode-hook)))
+
+(with-eval-after-load "init"
+  (gui-mode-initialize))


### PR DESCRIPTION
This creates a `gui-mode-hook` variable which can be used to add hooks to things you for whatever reason only want activated in a GUI-mode.

Examples: show-paren-mode, linum-mode, etc.

cc: @justinjk007 @alandmoore 